### PR TITLE
update compatibility version to v14 to use in foundryVTT new v14 version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "playlist_import",
-	"version": "13.0.3",
+	"version": "13.0.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "playlist_import",
-			"version": "13.0.3",
+			"version": "13.0.5",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@fortawesome/fontawesome-svg-core": "^6.5.1",

--- a/src/module.json
+++ b/src/module.json
@@ -72,8 +72,8 @@
   "styles": [],
   "compatibility": {
     "minimum": 13,
-    "verified": 13,
-    "maximum": 13
+    "verified": 14,
+    "maximum": 15
   },
   "url": "https://github.com/p4535992/foundryvtt-playlist-import",
   "manifest": "https://github.com/p4535992/foundryvtt-playlist-import/releases/download/13.0.5/module.json",


### PR DESCRIPTION
did some test with foundryVTT v14, just updated the module compatibility version and it seem to work "as is" (no changed seems needed)